### PR TITLE
replacing get_plugin_config by get_cached_config

### DIFF
--- a/src/nksip_config.erl
+++ b/src/nksip_config.erl
@@ -66,4 +66,4 @@ do_get_config(Key) ->
 
 
 srv_config(SrvId) ->
-    nkserver:get_plugin_config(SrvId, nksip, all_config).
+    nkserver:get_cached_config(SrvId, nksip, all_config).

--- a/src/plugins/nksip_event_compositor.erl
+++ b/src/plugins/nksip_event_compositor.erl
@@ -65,7 +65,7 @@ request(#sipmsg{class={req, 'PUBLISH'}}=Req) ->
         true -> 
             Expires;
         _ -> 
-            nkserver:get_plugin_config(SrvId, nksip_event_compositor, expires)
+            nkserver:get_cached_config(SrvId, nksip_event_compositor, expires)
     end,
     AOR = {RUri#uri.scheme, RUri#uri.user, RUri#uri.domain},
     case nksip_sipmsg:header(<<"sip-if-match">>, Req) of

--- a/src/plugins/nksip_registrar_lib.erl
+++ b/src/plugins/nksip_registrar_lib.erl
@@ -186,7 +186,7 @@ process(Req, Opts) ->
         true ->
             throw(unsupported_uri_scheme)
     end,
-    Times = nkserver:get_plugin_config(SrvId, nksip_registrar, times),
+    Times = nkserver:get_cached_config(SrvId, nksip_registrar, times),
     Default = case nksip_sipmsg:get_meta(expires, Req) of
         D0 when is_integer(D0), D0>=0 ->
             D0;

--- a/src/plugins/nksip_timers_lib.erl
+++ b/src/plugins/nksip_timers_lib.erl
@@ -520,4 +520,4 @@ start_timer(Time, Tag, Id) ->
 
 
 service_timers(SrvId) ->
-    nkserver:get_plugin_config(SrvId, nksip_timers, se_minse).
+    nkserver:get_cached_config(SrvId, nksip_timers, se_minse).

--- a/src/plugins/nksip_trace.erl
+++ b/src/plugins/nksip_trace.erl
@@ -124,7 +124,7 @@ print(Header, #sipmsg{}=SipMsg) ->
     ok.
 
 sipmsg(SrvId, _CallId, Header, Transport, Binary) ->
-    case nkserver:get_plugin_config(SrvId, nksip_trace, config) of
+    case nkserver:get_cached_config(SrvId, nksip_trace, config) of
         {true, File, []} ->
             Msg = print_packet(SrvId, Header, Transport, Binary),
             write(SrvId, File, Msg);

--- a/src/plugins/nksip_uac_auto_auth.erl
+++ b/src/plugins/nksip_uac_auto_auth.erl
@@ -65,11 +65,11 @@ check_auth(Req, Resp, UAC, Call) ->
             #call{srv_id=SrvId, call_id=_CallId} = Call,
             Max = case nklib_util:get_value(sip_uac_auto_auth_max_tries, Opts) of
                 undefined ->
-                    nkserver:get_plugin_config(SrvId, nksip_uac_auto_auth, max_tries);
+                    nkserver:get_cached_config(SrvId, nksip_uac_auto_auth, max_tries);
                 Max0 ->
                     Max0
             end,
-            ConfigPasses = nkserver:get_plugin_config(SrvId, nksip_uac_auto_auth, passwords),
+            ConfigPasses = nkserver:get_cached_config(SrvId, nksip_uac_auto_auth, passwords),
             Passes = case nklib_util:get_value(sip_pass, Opts) of
                 undefined ->
                     ConfigPasses;

--- a/src/plugins/nksip_uac_auto_outbound_callbacks.erl
+++ b/src/plugins/nksip_uac_auto_outbound_callbacks.erl
@@ -317,7 +317,7 @@ nksip_uac_auto_register_upd_reg(SrvId, Reg, Code, Meta, SrvState) ->
                 false ->
                     ok
             end,
-            Config = nkserver:get_plugin_config(SrvId, nksip_uac_auto_outbound, config),
+            Config = nkserver:get_cached_config(SrvId, nksip_uac_auto_outbound, config),
             #nksip_uac_auto_outbound{
                 max_time = MaxTime,
                 all_fail = AllFail,
@@ -362,7 +362,7 @@ start_refresh(SrvId, Meta, Transp, Pid, Reg) ->
         _ ->
             undefined
     end,
-    Config = nkserver:get_plugin_config(SrvId, nksip_uac_auto_outbound, config),
+    Config = nkserver:get_cached_config(SrvId, nksip_uac_auto_outbound, config),
     Secs = case FlowTimer of
         FT when is_integer(FT), FT > 5 ->
             FT;

--- a/src/plugins/nksip_uac_auto_register_callbacks.erl
+++ b/src/plugins/nksip_uac_auto_register_callbacks.erl
@@ -42,7 +42,7 @@
 %% ===================================================================
 
 srv_init(#{id:=SrvId}=Service, State) ->
-    Time = nkserver:get_plugin_config(SrvId, nksip_uac_auto_register, register_time),
+    Time = nkserver:get_cached_config(SrvId, nksip_uac_auto_register, register_time),
     erlang:start_timer(1000*Time, self(), nksip_uac_auto_register),
     State2 = State#{nksip_uac_auto_register=>#state{pings=[], regs=[], pids=[]}},
     {continue, [Service, State2]}.
@@ -235,7 +235,7 @@ srv_handle_cast(_Msg, _Service, _State) ->
 
 %% @private
 srv_handle_info({timeout, _, nksip_uac_auto_register}, #{id:=SrvId}, State) ->
-    Time = nkserver:get_plugin_config(SrvId, nksip_uac_auto_register, register_time),
+    Time = nkserver:get_cached_config(SrvId, nksip_uac_auto_register, register_time),
     erlang:start_timer(1000*Time, self(), nksip_uac_auto_register),
     gen_server:cast(self(), nksip_uac_auto_register_check),
     {noreply, State};

--- a/test/tests/t08_register.erl
+++ b/test/tests/t08_register.erl
@@ -82,7 +82,7 @@ stop() ->
 
 register1() ->
     #nksip_registrar_time{min=Min, max=Max, default=Def} =
-        nkserver:get_plugin_config(register_test_server1, nksip_registrar, times),
+        nkserver:get_cached_config(register_test_server1, nksip_registrar, times),
     MinB = nklib_util:to_binary(Min),
     MaxB = nklib_util:to_binary(Max),
     DefB = nklib_util:to_binary(Def),


### PR DESCRIPTION
Latest version of nksip does not use the latest version of nkserver.
Fixing the function calling :  `nkserver:get_plugin_config/3` into `nkserver:get_cached_config/3`